### PR TITLE
skip unused and duplicate workflow runs

### DIFF
--- a/.github/workflows/make-flavor.yaml
+++ b/.github/workflows/make-flavor.yaml
@@ -29,26 +29,44 @@ on:
         required: true
 
 jobs:
+  configure-workflow:
+    name: Configure workflow
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        name: Configure skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths: '[".github/**", "docker/**", "flavors/${{ inputs.flavor_name }}/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "release"]'
+
   build-naavre-cell-build:
     uses: ./.github/workflows/build-image.yaml
+    needs: configure-workflow
     with:
       dockerfile: naavre-cell-build.Dockerfile
       flavor_dir: './flavors/${{ inputs.flavor_name }}'
       image_name: naavre-cell-build-${{ inputs.flavor_name }}
       image_repo: ${{ inputs.image_repo }}
       image_version: ${{ inputs.image_version }}
+    if: ${{ needs.configure-workflow.outputs.should_skip != 'true' }}
 
   build-naavre-cell-runtime:
     uses: ./.github/workflows/build-image.yaml
+    needs: configure-workflow
     with:
       dockerfile: naavre-cell-runtime.Dockerfile
       flavor_dir: './flavors/${{ inputs.flavor_name }}'
       image_name: naavre-cell-runtime-${{ inputs.flavor_name }}
       image_repo: ${{ inputs.image_repo }}
       image_version: ${{ inputs.image_version }}
+    if: ${{ needs.configure-workflow.outputs.should_skip != 'true' }}
 
   build-naavre-jupyter:
     uses: ./.github/workflows/build-image.yaml
+    needs: configure-workflow
     with:
       dockerfile: naavre-jupyter.Dockerfile
       flavor_dir: './flavors/${{ inputs.flavor_name }}'
@@ -57,7 +75,7 @@ jobs:
       image_version: ${{ inputs.naavre_version }}-${{ inputs.image_version }}
       naavre_version: ${{ inputs.naavre_version }}
       free_disk_space: ${{ inputs.free_disk_space }}
-    if: ${{ inputs.build_jupyter }}
+    if: ${{ inputs.build_jupyter && needs.configure-workflow.outputs.should_skip != 'true'}}
 
   test:
     uses: ./.github/workflows/test-naavre-cell.yaml

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -12,12 +12,19 @@ on:
     - cron: '0 4 5,25 * *'
 
 jobs:
-  list-flavors:
-    name: List flavors
+  configure-workflow:
+    name: Configure workflow
     runs-on: ubuntu-latest
     outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
       matrix: ${{ steps.list-flavors.outputs.matrix }}
     steps:
+      - id: skip_check
+        name: Configure skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths_ignore: '["**/README.md"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "release"]'
       - uses: actions/checkout@v4
       - id: list-flavors
         name: List flavors
@@ -28,7 +35,8 @@ jobs:
   flavors:
     name: Flavor ${{ matrix.flavor_name }}
     uses: ./.github/workflows/make-flavor.yaml
-    needs: [list-flavors]
+    needs: [configure-workflow]
+    if: needs.configure-workflow.outputs.should_skip != 'true'
     with:
       flavor_name: ${{ matrix.flavor_name }}
       image_repo: 'ghcr.io/qcdis/naavre'
@@ -37,7 +45,7 @@ jobs:
       build_jupyter: ${{ matrix.build_jupyter }}
       free_disk_space: ${{ matrix.free_disk_space }}
     strategy:
-      matrix: ${{ fromJson(needs.list-flavors.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.configure-workflow.outputs.matrix) }}
 
   save-base-image-tags:
     name: Save base image tags


### PR DESCRIPTION
Using https://github.com/marketplace/actions/skip-duplicate-actions, we skip actions:

- skip everything if a successful identical workflow run exists
- skip everything if only a `README.md` is modified
- skip flavor if only files from another flavor were modified (only builds `my-flavor` if files are modified in `.github/`, `docker/`, or `flavors/my-flavor/`)
- do not skip anything on `release`, `workflow_dispatch` and `schedule`